### PR TITLE
Add saturday events to timetable

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5114,20 +5114,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/tree-sitter": {
-			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
-			"integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"node-addon-api": "^8.0.0",
-				"node-gyp-build": "^4.8.0"
-			}
-		},
 		"node_modules/tree-sitter-json": {
 			"version": "0.24.8",
 			"resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.24.8.tgz",

--- a/frontend/src/routes/timetable/+page.svelte
+++ b/frontend/src/routes/timetable/+page.svelte
@@ -67,7 +67,7 @@
                 minute: "numeric",
             },
             allDaySlot: false,
-            weekends: false,
+            weekends: true,
             slotMinTime: "08:00:00",
             slotMaxTime: "19:00:00",
             editable: false,

--- a/timetable/api.py
+++ b/timetable/api.py
@@ -313,6 +313,7 @@ class API:
                         {"DayOfWeek": 3},
                         {"DayOfWeek": 4},
                         {"DayOfWeek": 5},
+                        {"DayOfWeek": 6},
                     ],
                 },
                 "CategoryTypesWithIdentities": [


### PR DESCRIPTION
Fetch Saturday events in the API & enable weekend events on the timetable viewer.

Closes #22.