### PR TITLE
Add prometheus metrics

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,4 +12,9 @@ RUN uv sync --frozen
 
 COPY src src
 
-CMD ["uv", "run", "granian", "--interface", "asgi", "src.main:app", "--loop", "uvloop", "--workers", "4", "--host", "0.0.0.0", "--port", "2000"]
+ENV PROMETHEUS_MULTIPROC_DIR=/tmp/prometheus
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+CMD ["/entrypoint.sh"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+rm -rf "${PROMETHEUS_MULTIPROC_DIR}/*"
+mkdir -p "${PROMETHEUS_MULTIPROC_DIR}"
+
+exec uv run granian --interface asgi src.main:app --loop uvloop --workers 4 --host 0.0.0.0 --port 2000

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "fastapi[standard]>=0.135.0",
     "granian[uvloop]>=2.7.2",
     "msgspec>=0.20.0",
+    "prometheus-client>=0.25.0",
     "timetable-sync-api",
     "valkey-glide>=2.2.7",
 ]

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -2,7 +2,6 @@ import asyncio
 import datetime
 import logging
 import os
-import time
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator, Awaitable, Callable
 
@@ -15,11 +14,15 @@ from timetable.cns import API as CNSAPI
 from timetable.cns import GroupType
 from timetable.models import BasicCategoryItem, CategoryType
 
+from src import metrics
+from src.metrics import router as metrics_router
 from src.v2.routes import router as v2_router
 from src.v3.routes import cns_router as v3_cns_router
 from src.v3.routes import timetable_router as v3_timetable_router
 
 logger = logging.getLogger(__name__)
+
+CACHE_READY = asyncio.Event()
 
 
 async def load_all_categories_to_cache(
@@ -56,6 +59,7 @@ async def populate_cache(timetable_api: TimetableAPI, cns_api: CNSAPI) -> None:
     client = timetable_api.cache.client
 
     if await client.exists(["cache_ready"]):
+        CACHE_READY.set()
         logger.info("cache ready")
         return
 
@@ -76,13 +80,17 @@ async def populate_cache(timetable_api: TimetableAPI, cns_api: CNSAPI) -> None:
                     glide.ExpiryType.SEC, datetime.timedelta(days=1)
                 ),
             )
+
+            CACHE_READY.set()
+
         finally:
             await client.delete(["cache_loading"])
+
         return
+
     logger.info("waiting for cache")
 
-    while not await client.exists(["cache_ready"]):
-        await asyncio.sleep(0.2)
+    await CACHE_READY.wait()
 
     logger.info("cache ready")
 
@@ -121,6 +129,7 @@ app = FastAPI(
 app.include_router(v2_router, prefix="/api", tags=["v2"], deprecated=True)
 app.include_router(v3_timetable_router, prefix="/api/v3", tags=["v3"])
 app.include_router(v3_cns_router, prefix="/api/v3", tags=["v3"])
+app.include_router(metrics_router, prefix="/api", tags=["metrics"])
 
 ORIGINS = [
     "https://timetable.redbrick.dcu.ie",
@@ -136,6 +145,7 @@ app.add_middleware(
 
 
 @app.get("/api/healthcheck")
+@metrics.REQUEST_LATENCY.labels(endpoint="healthcheck", used_cache=None).time()
 async def healthcheck() -> str:
     return ":3"
 
@@ -144,13 +154,6 @@ async def healthcheck() -> str:
 async def log_request_process_times(
     request: Request, call_next: Callable[[Request], Awaitable[Response]]
 ) -> Response:
-    start_time = time.perf_counter()
     response = await call_next(request)
-    end_time = time.perf_counter()
-    execution_time_ms = (end_time - start_time) * 1000
-
-    logger.info(
-        f"request to '{request.url.path}{f'?{request.url.query}' if request.url.query else ''}' took {execution_time_ms:.4f} ms"
-    )
-
+    metrics.USER_AGENT_COUNT.labels(user_agent=request.headers["User-Agent"]).inc()
     return response

--- a/backend/src/metrics.py
+++ b/backend/src/metrics.py
@@ -1,0 +1,81 @@
+from fastapi import APIRouter, Response
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Counter,
+    Histogram,
+    generate_latest,
+    multiprocess,
+)
+
+router = APIRouter()
+
+
+REQUEST_LATENCY = Histogram(
+    "request_duration_seconds",
+    "HTTP request latency",
+    labelnames=["endpoint", "used_cache"],
+)
+
+USER_AGENT_COUNT = Counter(
+    "user_agent_counter",
+    "User Agent counter",
+    labelnames=["user_agent"],
+)
+
+EVENTS_COUNT = Histogram(
+    "events_per_request",
+    "Number of events per request",
+    labelnames=["category_type"],
+    buckets=[
+        1,
+        2,
+        5,
+        10,
+        15,
+        20,
+        25,
+        30,
+        40,
+        50,
+        75,
+        100,
+        125,
+        150,
+        175,
+        200,
+        225,
+        250,
+        275,
+        300,
+        325,
+        350,
+        375,
+        400,
+        450,
+        500,
+        600,
+        700,
+        800,
+        900,
+        1000,
+        1100,
+        1200,
+        1300,
+        1400,
+        1500,
+        1600,
+        1700,
+        1800,
+        1900,
+        2000,
+    ],
+)
+
+
+@router.get("/metrics")
+async def metrics() -> Response:
+    registry = CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry)
+    data = generate_latest(registry)
+    return Response(content=data, media_type=CONTENT_TYPE_LATEST)

--- a/backend/src/metrics.py
+++ b/backend/src/metrics.py
@@ -23,6 +23,12 @@ USER_AGENT_COUNT = Counter(
     labelnames=["user_agent"],
 )
 
+EVENTS_CATEGORY_IDENTITY_COUNT = Counter(
+    "events_category_identity_counter",
+    "Events category identity counts",
+    labelnames=["name", "identity"],
+)
+
 EVENTS_COUNT = Histogram(
     "events_per_request",
     "Number of events per request",

--- a/backend/src/v2/routes.py
+++ b/backend/src/v2/routes.py
@@ -1,5 +1,6 @@
 import collections
 import datetime
+import time
 from typing import Annotated
 
 import msgspec
@@ -8,6 +9,7 @@ from timetable import cns, models, utils
 from timetable.api import API as TimetableAPI  # noqa: N811
 from timetable.cns import API as CNSAPI
 
+from src import metrics
 from src.dependencies import get_cns_api, get_timetable_api
 
 router = APIRouter()
@@ -31,6 +33,8 @@ async def get_all_category_items(
     category_type: Annotated[str, Path()],
     query: Annotated[str | None, Query()] = None,
 ) -> Response:
+    start = time.perf_counter()
+
     if category_type not in ("course", "module", "location", "club", "society"):
         raise HTTPException(status_code=400, detail="Invalid value provided.")
 
@@ -57,8 +61,15 @@ async def get_all_category_items(
 
         items = [{"name": item.name, "identity": item.id} for item in items]
 
+    data = msgspec.json.encode(items)
+
+    duration = time.perf_counter() - start
+    metrics.REQUEST_LATENCY.labels(
+        endpoint="/v2/all/:category_type", used_cache=None
+    ).observe(duration)
+
     return Response(
-        content=msgspec.json.encode(items),
+        content=data,
         media_type="application/json",
     )
 
@@ -130,6 +141,8 @@ async def get_calendar_events(
         ),
     ] = None,
 ) -> Response:
+    start_ = time.perf_counter()
+
     if _format is None:
         _format = "ical"
 
@@ -169,8 +182,17 @@ async def get_calendar_events(
             media_type="text/calendar",
         )
     assert _format == "json"
+
+    data = msgspec.json.encode(events)
+
+    duration = time.perf_counter() - start_
+    metrics.REQUEST_LATENCY.labels(endpoint="/v2/", used_cache=None).observe(duration)
+    metrics.EVENTS_COUNT.labels(
+        category_type=",".join(sorted([category_type.name for category_type in codes]))
+    ).observe(len(events))
+
     return Response(
-        content=msgspec.json.encode(events),
+        content=data,
         media_type="application/json",
     )
 
@@ -181,6 +203,8 @@ async def get_cns_calendar_events(
     societies: Annotated[str | None, Query()] = None,
     clubs: Annotated[str | None, Query()] = None,
 ) -> Response:
+    start = time.perf_counter()
+
     if not (societies or clubs):
         raise HTTPException(status_code=400, detail="No societies or clubs provided.")
 
@@ -209,6 +233,11 @@ async def get_cns_calendar_events(
             events[item.name].extend(events_)
 
     calendar = cns.generate_ical_file(events)
+
+    duration = time.perf_counter() - start
+    metrics.REQUEST_LATENCY.labels(endpoint="/v2/cns", used_cache=None).observe(
+        duration
+    )
 
     return Response(
         content=calendar,

--- a/backend/src/v2/routes.py
+++ b/backend/src/v2/routes.py
@@ -187,6 +187,15 @@ async def get_calendar_events(
 
     duration = time.perf_counter() - start_
     metrics.REQUEST_LATENCY.labels(endpoint="/v2/", used_cache=None).observe(duration)
+    for category_type, ids in identities.items():
+        for item_id in ids:
+            metrics.EVENTS_CATEGORY_IDENTITY_COUNT.labels(
+                name=(
+                    await timetable_api.get_category_item(item_id)
+                    or await timetable_api.fetch_category_item(category_type, item_id)
+                ).name,
+                identity=item_id,
+            ).inc()
     metrics.EVENTS_COUNT.labels(
         category_type=",".join(sorted([category_type.name for category_type in codes]))
     ).observe(len(events))

--- a/backend/src/v3/routes.py
+++ b/backend/src/v3/routes.py
@@ -2,6 +2,7 @@ import collections
 import datetime
 import enum
 import logging
+import time
 from typing import Annotated
 from uuid import UUID
 
@@ -11,6 +12,7 @@ from timetable import cns, models, utils
 from timetable.api import API as TimetableAPI  # noqa: N811
 from timetable.cns import API as CNSAPI
 
+from src import metrics
 from src.dependencies import get_cns_api, get_timetable_api
 
 logger = logging.getLogger(__name__)
@@ -46,16 +48,27 @@ async def get_timetable_category_items(
     category_type: Annotated[CategoryType, Path()],
     query: Annotated[str | None, Query()] = None,
 ) -> Response:
+    start = time.perf_counter()
+    used_cache: bool = True
+
     category = await timetable_api.get_category(
         category_type.to_model(), query=query, items_type=models.BasicCategoryItem
     )
     if not category:
+        used_cache = False
         category = await timetable_api.fetch_category(
             category_type.to_model(), query=query, items_type=models.BasicCategoryItem
         )
 
+    data = msgspec.json.encode(category.items)
+
+    duration = time.perf_counter() - start
+    metrics.REQUEST_LATENCY.labels(
+        endpoint="/v3/timetable/category/:category_type/items", used_cache=used_cache
+    ).observe(duration)
+
     return Response(
-        content=msgspec.json.encode(category.items),
+        content=data,
         media_type="application/json",
     )
 
@@ -66,11 +79,24 @@ async def get_timetable_category_item(
     category_type: Annotated[CategoryType, Path()],
     item_id: Annotated[UUID, Path()],
 ) -> Response:
-    item = await timetable_api.get_category_item(
-        item_id
-    ) or await timetable_api.fetch_category_item(category_type.to_model(), item_id)
+    start = time.perf_counter()
+    used_cache: bool = True
+
+    item = await timetable_api.get_category_item(item_id)
+    if not item:
+        used_cache = False
+        await timetable_api.fetch_category_item(category_type.to_model(), item_id)
+
+    data = msgspec.json.encode(item)
+
+    duration = time.perf_counter() - start
+    metrics.REQUEST_LATENCY.labels(
+        endpoint="/v3/timetable/category/:category_type/items/:item_id",
+        used_cache=used_cache,
+    ).observe(duration)
+
     return Response(
-        content=msgspec.json.encode(item),
+        content=data,
         media_type="application/json",
     )
 
@@ -85,6 +111,8 @@ async def get_timetable_category_item_events(
     extra_details: Annotated[ExtraDetails, Query()] = ExtraDetails.NONE,
     media_type: Annotated[str, Header()] = "text/calendar",
 ) -> Response:
+    start_ = time.perf_counter()
+
     if media_type not in {"text/calendar", "application/json"}:
         raise HTTPException(400, "Invalid media type provided.")
 
@@ -98,6 +126,15 @@ async def get_timetable_category_item_events(
         # TODO: handle extra_details
         # display = extra_details is ExtraDetails.ALL
         timetable = msgspec.json.encode(events)
+
+    duration = time.perf_counter() - start_
+    metrics.REQUEST_LATENCY.labels(
+        endpoint="/v3/timetable/category/:category_type/items/:item_id/events",
+        used_cache=None,
+    ).observe(duration)
+    metrics.EVENTS_COUNT.labels(category_type=category_type.to_model().name).observe(
+        len(events)
+    )
 
     return Response(
         content=timetable,
@@ -127,6 +164,7 @@ async def get_timetable_calendar_events(
     extra_details: Annotated[ExtraDetails, Query()] = ExtraDetails.NONE,
     media_type: Annotated[str, Header()] = "text/calendar",
 ) -> Response:
+    start_ = time.perf_counter()
     if not course and not module and not location:
         raise HTTPException(
             status_code=400, detail="No course(s), module(s) or location(s) provided."
@@ -151,6 +189,18 @@ async def get_timetable_calendar_events(
         # display = extra_details is ExtraDetails.ALL
         timetable = msgspec.json.encode(events)
 
+    duration = time.perf_counter() - start_
+    metrics.REQUEST_LATENCY.labels(
+        endpoint="/v3/timetable/events", used_cache=None
+    ).observe(duration)
+    metrics.EVENTS_COUNT.labels(
+        category_type=",".join(
+            sorted(
+                [category_type.name for category_type, ids in identities.items() if ids]
+            )
+        )
+    ).observe(len(events))
+
     return Response(
         content=timetable,
         media_type=media_type,
@@ -166,12 +216,23 @@ async def get_cns_category_items(
     category_type: Annotated[cns.GroupType, Path()],
     query: Annotated[str | None, Query()] = None,
 ) -> Response:
+    start = time.perf_counter()
+    used_cache: bool = True
+
     items = await cns_api.get_group_items(category_type, query)
     if not items:
+        used_cache = False
         items = await cns_api.fetch_group_items(category_type, query)
 
+    data = msgspec.json.encode(items)
+
+    duration = time.perf_counter() - start
+    metrics.REQUEST_LATENCY.labels(
+        endpoint="/v3/cns/category/:category_type/items", used_cache=used_cache
+    ).observe(duration)
+
     return Response(
-        content=msgspec.json.encode(items),
+        content=data,
         media_type="application/json",
     )
 
@@ -182,12 +243,23 @@ async def get_cns_category_item(
     category_type: Annotated[cns.GroupType, Path()],
     item_id: Annotated[str, Path()],
 ) -> Response:
+    start = time.perf_counter()
+    used_cache: bool = True
+
     item = await cns_api.get_item(item_id)
     if not item:
+        used_cache = False
         item = await cns_api.fetch_item(category_type, item_id)
 
+    data = msgspec.json.encode(item)
+
+    duration = time.perf_counter() - start
+    metrics.REQUEST_LATENCY.labels(
+        endpoint="/v3/cns/category/:category_type/items/:item_id", used_cache=used_cache
+    ).observe(duration)
+
     return Response(
-        content=msgspec.json.encode(item),
+        content=data,
         media_type="application/json",
     )
 
@@ -200,6 +272,8 @@ async def get_cns_calendar_events(
     society: Annotated[list[str], Query()] = [],
     club: Annotated[list[str], Query()] = [],
 ) -> Response:
+    start = time.perf_counter()
+
     if not (society or club):
         raise HTTPException(
             status_code=400, detail="No club(s) or society(s) provided."
@@ -227,6 +301,11 @@ async def get_cns_calendar_events(
             events[item.name].extend(events_)
 
     calendar = cns.generate_ical_file(events)
+
+    duration = time.perf_counter() - start
+    metrics.REQUEST_LATENCY.labels(endpoint="/v3/cns/events", used_cache=None).observe(
+        duration
+    )
 
     return Response(
         content=calendar,

--- a/backend/src/v3/routes.py
+++ b/backend/src/v3/routes.py
@@ -132,6 +132,15 @@ async def get_timetable_category_item_events(
         endpoint="/v3/timetable/category/:category_type/items/:item_id/events",
         used_cache=None,
     ).observe(duration)
+    metrics.EVENTS_CATEGORY_IDENTITY_COUNT.labels(
+        name=(
+            await timetable_api.get_category_item(item_id)
+            or await timetable_api.fetch_category_item(
+                category_type.to_model(), item_id
+            )
+        ).name,
+        identity=item_id,
+    ).inc()
     metrics.EVENTS_COUNT.labels(category_type=category_type.to_model().name).observe(
         len(events)
     )
@@ -193,6 +202,15 @@ async def get_timetable_calendar_events(
     metrics.REQUEST_LATENCY.labels(
         endpoint="/v3/timetable/events", used_cache=None
     ).observe(duration)
+    for category_type, ids in identities.items():
+        for item_id in ids:
+            metrics.EVENTS_CATEGORY_IDENTITY_COUNT.labels(
+                name=(
+                    await timetable_api.get_category_item(item_id)
+                    or await timetable_api.fetch_category_item(category_type, item_id)
+                ).name,
+                identity=item_id,
+            ).inc()
     metrics.EVENTS_COUNT.labels(
         category_type=",".join(
             sorted(

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -820,6 +820,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1333,6 +1342,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "granian", extra = ["uvloop"] },
     { name = "msgspec" },
+    { name = "prometheus-client" },
     { name = "timetable-sync-api" },
     { name = "valkey-glide" },
 ]
@@ -1353,6 +1363,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.0" },
     { name = "granian", extras = ["uvloop"], specifier = ">=2.7.2" },
     { name = "msgspec", specifier = ">=0.20.0" },
+    { name = "prometheus-client", specifier = ">=0.25.0" },
     { name = "timetable-sync-api", git = "https://github.com/novanai/timetable-sync-api" },
     { name = "valkey-glide", specifier = ">=2.2.7" },
 ]


### PR DESCRIPTION
Adds some prometheus metrics for measuring request latency, user agent counts and event counts.

Examples:
<img width="1379" height="934" src="https://github.com/user-attachments/assets/733c5905-0940-4d7f-af8b-9b8689e4f0fe" />
<img width="1389" height="680" src="https://github.com/user-attachments/assets/d0d28a35-95ea-42fb-83b3-414412c91c36" />
